### PR TITLE
Fixes behavior and documentation around name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea/*

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Options:
                                                                  [default: true]
   --dir, -d     specify a module directory. defaults to your current working
                 directory       [default: "/home/soldair/projects/npm/scope-it"]
-  --name        set this to 0 if you d not want to also update this module's
+  --name        set this to 0 if you do not want to also update this module's
                 scope                                            [default: true]
   -h, --help    Show help                                              [boolean]
   --version     Show version number                                    [boolean]

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -21,7 +21,7 @@ var yargs = require('yargs')
     describe:"specify a module directory. defaults to your current working directory"
   })
   .option('name',{
-    describe:"set this to 0 if you d not want to also update this module's scope",
+    describe:"set this to 0 if you do not want to also update this module's scope",
     default:true
   })
   .help('h')
@@ -44,6 +44,7 @@ var scope = argv.scope
 var modules = argv._
 var dir = path.resolve(process.cwd(),argv.dir)
 
+var scopeName = argv.name
 var dryRun = argv.dry
 var jsonPath = path.join(dir,'package.json')
 var pkg = require(jsonPath)
@@ -51,8 +52,9 @@ var pkg = require(jsonPath)
 if(dryRun) ui.banner("     DRY RUN")
 
 // scope or unscope
-var origName = pkg.name
-pkg.name = (scope.length?scope+'/':'')+pkg.name.split('/').pop();
+if (scopeName){
+  pkg.name = (scope.length?scope+'/':'')+pkg.name.split('/').pop();
+}
 // dependencies
 pkg.dependencies = updateDeps(scope,pkg.dependencies||{},modules)
 // devDependencies


### PR DESCRIPTION
The name parameter was originally not being used, and there was a typo
in the documentation for the parameter. Have resolved the typo, and have also made it so the parameter is used in the way that the documentation specifies.
