### PR TITLE
prefix test folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .idea/*
+test/run-*

--- a/test/common/helper.js
+++ b/test/common/helper.js
@@ -8,7 +8,7 @@ var ts = require('monotonic-timestamp')
 module.exports = {
   makeTest:function(cb){
     var from  = path.resolve(__dirname,'..','fixture','package')
-    var dest = path.resolve(__dirname,'..',ts()+'')
+    var dest = path.resolve(__dirname,'..','run-'+ts())
 
     console.log(from,dest)
 
@@ -46,7 +46,7 @@ module.exports = {
         try {
           rimraf.sync(files.shift())
         } catch(e) {
-          if(files.length === start) throw e    
+          if(files.length === start) throw e
         }
       }
       if (err) process.emit('error', err)


### PR DESCRIPTION
- update .gitignore

This will keep ancillary test folders from being committed should you kill the test prematurely.
